### PR TITLE
Added init container to fix permissions

### DIFF
--- a/charts/node-red/Chart.yaml
+++ b/charts/node-red/Chart.yaml
@@ -9,7 +9,7 @@ icon: https://nodered.org/about/resources/media/node-red-icon-2.png
 
 type: application
 
-version: 0.3.2
+version: 0.3.3
 appVersion: "2.1.4"
 
 keywords:
@@ -24,8 +24,9 @@ maintainers:
     url: https://jobs.schwarz
 
 annotations:
-  artifacthub.io/containsSecurityUpdates: "true"
+  artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
+    - Added initcontainer to deployment
     - Updated node-red image to 2.1.4
     - Updated node-red image to 2.1.3
   artifacthub.io/images: |

--- a/charts/node-red/templates/deployment.yaml
+++ b/charts/node-red/templates/deployment.yaml
@@ -25,6 +25,17 @@ spec:
       serviceAccountName: {{ include "node-red.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.persistence.enabled }}
+      initContainers:
+        - name: permission-fix
+          image: busybox
+          command: ['sh', '-c']
+          args: ['chmod -R 777 /data']
+          volumeMounts:
+            - name: data
+              mountPath: /data
+              subPath: {{ .Values.persistence.subPath }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:


### PR DESCRIPTION
This pull request added an init container to the deployment.yml.
The #22 shows that this is a bug, when using persistent volume claims, since their permission is incorrect and need to be changed.

## Try the fix

```bash
helm repo add node-red https://schwarzit.github.io/node-red-chart/
helm repo update
helm upgrade --install node-red node-red/node-red -f values.yml --namespace dev --version 0.3.2
```

While the values.yml is defined as follows:

```yaml
replicaCount: 1

env:
  - name: "TZ"
    value: "UTC"
  - name: "NODE_RED_ENABLE_SAFE_MODE"
    value: "false"
  - name: "NODE_RED_ENABLE_PROJECTS"
    value: "false"
  - name: "FLOWS"
    value: "flows.json"

persistence:
  enabled: true
  accessMode: ReadWriteOnce
  size: 10Gi

ingress:
  enabled: false

resources:
  limits:
    cpu: 100m
    memory: 256Mi

service:
  type: NodePort
  port: 1880
 ```
 
 ```bash
 kubectl port-forward service/node-red 1880:1880 --namespace dev
 ```
 