### PR TITLE
fix: change port name of servicemonitor to default port

### DIFF
--- a/charts/node-red/Chart.yaml
+++ b/charts/node-red/Chart.yaml
@@ -9,7 +9,7 @@ icon: https://nodered.org/about/resources/media/node-red-icon-2.png
 
 type: application
 
-version: 0.13.1
+version: 0.13.2
 appVersion: 2.2.2
 
 keywords:
@@ -29,7 +29,7 @@ maintainers:
 annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - support for prometheus metrics
+    - change port name of servicemonitor to default port
   artifacthub.io/images: |
     - name: node-red
       image: docker.io/nodered/node-red:2.2.2

--- a/charts/node-red/README.md
+++ b/charts/node-red/README.md
@@ -1,12 +1,11 @@
 # node-red ⚙
 
-![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.1-informational?style=for-the-badge)
-![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) 
-![AppVersion: 2.2.2](https://img.shields.io/badge/AppVersion-2.2.2-informational?style=for-the-badge) 
+![Version: 0.13.2](https://img.shields.io/badge/Version-0.13.2-informational?style=for-the-badge)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge)
+![AppVersion: 2.2.2](https://img.shields.io/badge/AppVersion-2.2.2-informational?style=for-the-badge)
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/node-red&style=for-the-badge)](https://artifacthub.io/packages/search?repo=node-red)
 [![SIT](https://img.shields.io/badge/SIT-awesome-blueviolet.svg?style=for-the-badge)](https://jobs.schwarz)
-
 
 <img src="https://nodered.org/about/resources/media/node-red-icon-2.png" width="80" height="80">
 
@@ -27,7 +26,7 @@ helm repo update
 To install the chart with the release name node-red run:
 
 ```bash
-helm install node-red node-red/node-red --version 0.13.1
+helm install node-red node-red/node-red --version 0.13.2
 ```
 
 After a few seconds, node-red should be running.
@@ -35,7 +34,7 @@ After a few seconds, node-red should be running.
 To install the chart in a specific namespace use following commands:
 
 ```bash
-kubectl create ns node-red 
+kubectl create ns node-red
 helm install node-red node-red/node-red --namespace node-red
 ```
 

--- a/charts/node-red/templates/servicemonitor.yaml
+++ b/charts/node-red/templates/servicemonitor.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-    - port: metrics
+    - port: http
       {{- with .Values.metrics.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}


### PR DESCRIPTION
Signed-off-by: Engin Diri <engin.diri@mail.schwarz>

### Thank you for making `node-red ⚙` better

Please reference the issue this PR is fixing.

*Also verify you have:*

* [x] Read the [contributions](../CONTRIBUTING.md) page.
* [x] Read the [DCO](../DCO), if you are a first time contributor.
* [x] Read the [code of conduct]([Code of Conduct](https://github.com/SchwarzIT/.github/blob/main/CODE_OF_CONDUCT.md)).