### PR TITLE
Change indention for .Values.env to twelve

### DIFF
--- a/charts/node-red/templates/deployment.yaml
+++ b/charts/node-red/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         {{- if .Values.sidecar.enabled }}
         - env:
           {{- if .Values.sidecar.extraEnv }}
-          {{- toYaml .Values.sidecar.extraEnv  | nindent 10 }}
+          {{- toYaml .Values.sidecar.extraEnv  | nindent 12 }}
           {{- end }}
             - name: METHOD
               value: {{ .Values.sidecar.env.method }}

--- a/charts/node-red/templates/deployment.yaml
+++ b/charts/node-red/templates/deployment.yaml
@@ -121,7 +121,7 @@ spec:
               value: {{ .Values.metrics.path | default "/metrics" }}
           {{- end }}
           {{- with .Values.env }}
-          {{- toYaml .| nindent 10 }}
+          {{- toYaml .| nindent 12 }}
           {{- end }}
           {{- end }}
           ports:


### PR DESCRIPTION
In a prior commit the indention for env vars changed by adding an extra indent. Now when setting the following combinations the chart fails to render due to the indention levels of the environment variables being off by one:

1. `.Values.env` and `.Values.metrics.enabled == true`
1. `.Values.sidecar.extraEnv` and `.Values.sidecar.enabled == true` 

This changes the indention from 10 to 12 for those two env settings which allows the chart to render

Signed-off-by: Thomas Miller <git@me.tmiller.dev>

### Thank you for making `node-red ⚙` better

Please reference the issue this PR is fixing.

*Also verify you have:*

* [X] Read the [contributions](../CONTRIBUTING.md) page.
* [X] Read the [DCO](../DCO), if you are a first time contributor.
* [X] Read the [code of conduct]([Code of Conduct](https://github.com/SchwarzIT/.github/blob/main/CODE_OF_CONDUCT.md)).