### PR TITLE
Fixed memory limit

### DIFF
--- a/charts/node-red/values.yaml
+++ b/charts/node-red/values.yaml
@@ -185,7 +185,7 @@ resources:
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
     cpu: 500m
-    memory: 5123Mi
+    memory: 512Mi
   requests:
     cpu: 100m
     memory: 128Mi


### PR DESCRIPTION
Changed the memory limit from 5123MB to 512MB.
512MB RAM should be enough for node-red.