### PR TITLE
Replaced flow_refresh.sh w flow_refresh.py script

### DIFF
--- a/charts/node-red/Chart.yaml
+++ b/charts/node-red/Chart.yaml
@@ -9,7 +9,7 @@ icon: https://nodered.org/about/resources/media/node-red-icon-2.png
 
 type: application
 
-version: 0.23.2
+version: 0.24.0
 appVersion: 3.0.2
 
 keywords:
@@ -29,7 +29,7 @@ maintainers:
 annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - update quay.io/kiwigrid/k8s-sidecar to 1.24.0
+    - change flow_refresh.sh to flow_refresh.py, this is a breaking change.
   artifacthub.io/images: |
     - name: node-red
       image: docker.io/nodered/node-red:3.0.2

--- a/charts/node-red/scripts/flow_refresh.py
+++ b/charts/node-red/scripts/flow_refresh.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+import time
+import os
+import requests
+import json
+import sys
+import re
+
+# SET VARIABLES FROM CONTAINER ENVIRONMENT
+SLEEP_TIME_SIDECAR = 5 if os.getenv("SLEEP_TIME_SIDECAR") is None else int(re.sub('[A-z]', "",os.getenv("SLEEP_TIME_SIDECAR")))
+USERNAME = os.getenv("USERNAME")
+PASSWORD = os.getenv("PASSWORD")
+URL = os.getenv("URL")
+
+print('node-red flow refresh api call via k8s-sidecar')
+print('sidecar sleeping for', SLEEP_TIME_SIDECAR, 'seconds...')
+time.sleep(SLEEP_TIME_SIDECAR)
+
+# GET NODE RED BEARER TOKEN
+PAYLOAD_TOKEN = {"client_id": "node-red-admin", "grant_type": "password", "scope": "*", "username": USERNAME, "password": PASSWORD}
+r_token = requests.post(URL + '/auth/token', data=PAYLOAD_TOKEN, timeout=30)
+if r_token.status_code == requests.codes.ok:
+    print('node-red bearer token successfully created -', r_token.status_code)  
+    token = (json.loads(r_token.text)["access_token"])
+else:
+    print('could not create bearer token....', r_token.status_code) 
+    sys.exit('Error-Code -', r_token.status_code)
+
+# FLOW REFRESH/RELOAD FLOWS FROM SECRET/CONFIGMAP
+PAYLOAD_FLOW_REFRESH = "{\"flows\": [{\"type\": \"tab\"}]}"
+HEADERS_FLOW_REFRESH={
+  'Authorization': 'Bearer' + ' ' + token,
+  'content-type': 'application/json; charset=utf-8',
+  'Node-RED-Deployment-Type': 'reload',
+  'Node-RED-API-Version': 'v2'
+}
+
+r_flow_refresh = requests.post(URL + '/flows', headers=HEADERS_FLOW_REFRESH, data=PAYLOAD_FLOW_REFRESH, timeout=30) 
+
+if r_flow_refresh.status_code == requests.codes.ok:
+    print('node-red flows successfully reloaded -', r_flow_refresh.status_code)
+    sys.exit(0)   
+else:
+    sys.exit('Error-Code', r_flow_refresh.status_code)

--- a/charts/node-red/scripts/flow_refresh.sh
+++ b/charts/node-red/scripts/flow_refresh.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-echo "node-red flow refresh api"
-sleep $SLEEP_TIME_SIDECAR
-token=$(curl -X POST -sSk --connect-timeout 30 --retry 50 --retry-delay 10 --data "client_id=node-red-admin&grant_type=password&scope=*&username=$USERNAME&password=$PASSWORD" $URL/auth/token | grep "^{" |  jq -r .access_token)
-curl -k -X POST --connect-timeout 30 --retry 50 --retry-delay 10 -H "Authorization: Bearer $token" -H "content-type: application/json; charset=utf-8" -H "Node-RED-Deployment-Type: reload" -H "Node-RED-API-Version: v2"  --data '{"flows": [{"type": "tab"}]}' $URL/flows

--- a/charts/node-red/templates/sidecar-cm.yaml
+++ b/charts/node-red/templates/sidecar-cm.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.sidecar.enabled }}
 apiVersion: v1
 data:
-  flow_refresh.sh: | {{ range $.Files.Lines "scripts/flow_refresh.sh" }}
+  flow_refresh.py: | {{ range $.Files.Lines "scripts/flow_refresh.py" }}
     {{ . }}{{ end }}
 kind: ConfigMap
 metadata:

--- a/charts/node-red/values.yaml
+++ b/charts/node-red/values.yaml
@@ -247,7 +247,7 @@ sidecar:
     # -- The value for the label you want to filter your resources on. Don't set a value to filter by any value
     label_value: "1"
     # -- Absolute path to shell script to execute after a configmap got reloaded.
-    script: flow_refresh.sh
+    script: flow_refresh.py
     # The username for the API Call, check node-red documentation for more information
     username: ""
     # -- Password as key value pair


### PR DESCRIPTION
### Thank you for making `node-red ⚙` better

Please reference the issue this PR is fixing:

This PR will fix the flow_refresh workflow within the k8s-sidecar documented in this[ issue ](https://github.com/SchwarzIT/node-red-chart/issues/236)
+ the original flow_refresh.sh script is failing due to sh dependenyies not installed in the image (curl, jq)
+ k8s-sidecar is python based an better fit python modules and enviroments for advanced script tasks, discussed [here](https://github.com/kiwigrid/k8s-sidecar/issues/271)
+ k8s-sidecar update to 1.24.0 to fix scripts shebangs and properly run python scripts[ FR/PR](https://github.com/kiwigrid/k8s-sidecar/pull/276)
+ rewrote the flow_script in python an replaced it 
+ changed default helm values [sidecar.env.script to flow_refresh.py](url) and `sidecar.image.tag to 1.24.0 `

*Also verify you have:*

* [x] Read the [contributions](../CONTRIBUTING.md) page.
* [x] Read the [DCO](../DCO), if you are a first time contributor.
* [x] Read the [code of conduct]([Code of Conduct](https://github.com/SchwarzIT/.github/blob/main/CODE_OF_CONDUCT.md)).