### PR TITLE
Allow specifying environment variables from secrets.

### DIFF
--- a/charts/node-red/Chart.yaml
+++ b/charts/node-red/Chart.yaml
@@ -9,7 +9,7 @@ icon: https://nodered.org/about/resources/media/node-red-icon-2.png
 
 type: application
 
-version: 0.26.0
+version: 0.27.0
 appVersion: 3.0.2
 
 keywords:
@@ -29,7 +29,7 @@ maintainers:
 annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - add role and clusterrole to chart
+    - allow specifying environment variables from secrets
   artifacthub.io/images: |
     - name: node-red
       image: docker.io/nodered/node-red:3.0.2

--- a/charts/node-red/templates/deployment.yaml
+++ b/charts/node-red/templates/deployment.yaml
@@ -124,7 +124,13 @@ spec:
             value: {{ .Values.metrics.path | default "/metrics" }}
           {{- end }}
           {{- with .Values.env }}
-          {{- toYaml .| nindent 10 }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.envFrom }}
+          envFrom:
+          {{- with .Values.envFrom }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- end }}
           ports:

--- a/charts/node-red/values.yaml
+++ b/charts/node-red/values.yaml
@@ -44,6 +44,10 @@ env: []
   # env:
   # - name: "NODE_RED_ENABLE_SAFE_MODE"
   #   value: ""
+envFrom: []
+  # Possible values:
+  # - secretRef:
+  #     name: node-red-env
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
I am currently still using the `node-red` Helm chart from https://github.com/k8s-at-home/charts and want to switch to this chart. I am specifying environment variables with secrets using `envFrom`, this adds support for the corresponding values.

*Also verify you have:*

* [x] Read the [contributions](../CONTRIBUTING.md) page.
* [x] Read the [DCO](../DCO), if you are a first time contributor.
* [x] Read the [code of conduct]([Code of Conduct](https://github.com/SchwarzIT/.github/blob/main/CODE_OF_CONDUCT.md)).
