### PR TITLE
Support to specify a certain version for extra node modules instead of latest every time

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: 3.7
 
       - name: Run Trivy vulnerability scanner in IaC mode
-        uses: aquasecurity/trivy-action@91713af97dc80187565512baba96e4364e983601 # 0.16.0
+        uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca # 0.16.1
         with:
           scan-type: 'config'
           hide-progress: false

--- a/charts/node-red/README.md
+++ b/charts/node-red/README.md
@@ -130,7 +130,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | sidecar.env.sleep_time_sidecar | string | `"5s"` | Set the sleep time for refresh script |
 | sidecar.env.username | string | `""` |  |
 | sidecar.extraEnv | list | `[]` | Extra Environments for the sidecar |
-| sidecar.extraNodeModules | list | `[]` | Extra Node-Modules that will be installed  from the sidecar script |
+| sidecar.extraNodeModules | list | `[]` | Extra Node-Modules that will be installed from the sidecar script (specifying a version like node-red-contrib-example@1.2.3 is supported) |
 | sidecar.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy, default: `IfNotPresent` |
 | sidecar.image.registry | string | `"quay.io"` | The image registry to pull the sidecar from |
 | sidecar.image.repository | string | `"kiwigrid/k8s-sidecar"` | The image repository to pull from |

--- a/charts/node-red/README.md
+++ b/charts/node-red/README.md
@@ -178,7 +178,7 @@ Default values are: `node-red-settings:1`.
 The `k8s-sidecar` will then call the `node-red` api to reload the flows. This will be done via a script. To run this script successfully you need to provide the `username` and `password`
 of your admin user. The admin user needs to have the right to use the `node-red` API.
 
-The `k8s-sidecar` can also call the `node-red` api to install additional node modules (npm packages) before refreshing or importing the flow.json.
+The `k8s-sidecar` can also call the `node-red` api to install additional node modules (npm packages) before refreshing or importing the flow.json. Specifying a version for a module is supported (s. example below).
 You need to list your flows requiert 'NODE_MODULES' in the `sidecar.extraNodeModules`: e.g.
 
 ```yaml
@@ -186,7 +186,7 @@ sidecar:
  extraNodeModules:
     - node-red-contrib-xkeys_setunitid
     - node-red-contrib-microsoft-teams-tasks
-    - node-red-contrib-json
+    - node-red-contrib-json@0.2.0
 ```
 To install the node modules successfully, the node red pod needs access to the `npmrc.registry` to download the declaired modules/packages.
 

--- a/charts/node-red/README.md
+++ b/charts/node-red/README.md
@@ -1,4 +1,4 @@
-# node-red ⚙
+****# node-red ⚙
 
 ![Version: 0.28.1](https://img.shields.io/badge/Version-0.28.1-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 3.0.2](https://img.shields.io/badge/AppVersion-3.0.2-informational?style=for-the-badge)
 
@@ -179,7 +179,7 @@ The `k8s-sidecar` will then call the `node-red` api to reload the flows. This wi
 of your admin user. The admin user needs to have the right to use the `node-red` API.
 
 The `k8s-sidecar` can also call the `node-red` api to install additional node modules (npm packages) before refreshing or importing the flow.json. Specifying a version for a module is supported (s. example below).
-You need to list your flows requiert 'NODE_MODULES' in the `sidecar.extraNodeModules`: e.g.
+You need to list your flows required 'NODE_MODULES' in the `sidecar.extraNodeModules`: e.g.
 
 ```yaml
 sidecar:

--- a/charts/node-red/README.md.gotmpl
+++ b/charts/node-red/README.md.gotmpl
@@ -96,7 +96,7 @@ The `k8s-sidecar` will then call the `node-red` api to reload the flows. This wi
 of your admin user. The admin user needs to have the right to use the `node-red` API.
 
 The `k8s-sidecar` can also call the `node-red` api to install additional node modules (npm packages) before refreshing or importing the flow.json.
-You need to list your flows requiert 'NODE_MODULES' in the `sidecar.extraNodeModules`: e.g.
+You need to list your flows required 'NODE_MODULES' in the `sidecar.extraNodeModules`: e.g.
 
 ```yaml
 sidecar:

--- a/charts/node-red/README.md.gotmpl
+++ b/charts/node-red/README.md.gotmpl
@@ -95,7 +95,7 @@ Default values are: `node-red-settings:1`.
 The `k8s-sidecar` will then call the `node-red` api to reload the flows. This will be done via a script. To run this script successfully you need to provide the `username` and `password`
 of your admin user. The admin user needs to have the right to use the `node-red` API.
 
-The `k8s-sidecar` can also call the `node-red` api to install additional node modules (npm packages) before refreshing or importing the flow.json.
+The `k8s-sidecar` can also call the `node-red` api to install additional node modules (npm packages) before refreshing or importing the flow.json. Specifying a version for a module is supported (s. example below).
 You need to list your flows required 'NODE_MODULES' in the `sidecar.extraNodeModules`: e.g.
 
 ```yaml

--- a/charts/node-red/scripts/flow_refresh.py
+++ b/charts/node-red/scripts/flow_refresh.py
@@ -108,12 +108,15 @@ def main():
 
         for module in EXTRA_NODE_MODULES:
             if module not in modules_installed:
-               module_name, version = module.split('@') if '@' in module else (module, None)
-               payload_node_module = ''
-               if version is not None:
-                   payload_node_module = '{"module": "' + module_name + '", "version": "' + version + '"}'
-               else:
-                   payload_node_module = '{"module": "' + module_name + '"}'
+                try
+                    module_name, version = module.rsplit('/', 1)[-1].split('@', 1) if '@' in module else (module, None)
+                except ValueError:
+                    module_name, version = module, None
+                payload_node_module = ''
+                if version is not None:
+                    payload_node_module = '{"module": "' + module_name + '", "version": "' + version + '"}'
+                else:
+                    payload_node_module = '{"module": "' + module_name + '"}'
                 headers_node_module = {
                     "Content-type": "application/json",
                 }

--- a/charts/node-red/scripts/flow_refresh.py
+++ b/charts/node-red/scripts/flow_refresh.py
@@ -108,7 +108,12 @@ def main():
 
         for module in EXTRA_NODE_MODULES:
             if module not in modules_installed:
-                payload_node_module = '{"module": "' + module + '"}'
+               module_name, version = module.split('@') if '@' in module else (module, None)
+               payload_node_module = ''
+               if version is not None:
+                   payload_node_module = '{"module": "' + module_name + '", "version": "' + version + '"}'
+               else:
+                   payload_node_module = '{"module": "' + module_name + '"}'
                 headers_node_module = {
                     "Content-type": "application/json",
                 }

--- a/charts/node-red/scripts/flow_refresh.py
+++ b/charts/node-red/scripts/flow_refresh.py
@@ -108,9 +108,9 @@ def main():
 
         for module in EXTRA_NODE_MODULES:
             if module not in modules_installed:
-                try
+                try:
                     module_name, version = module.rsplit('/', 1)[-1].split('@', 1) if '@' in module else (module, None)
-                except ValueError:
+                except:
                     module_name, version = module, None
                 payload_node_module = ''
                 if version is not None:


### PR DESCRIPTION
### Thank you for making `node-red ⚙` better

This PR is adding optional support for versions within extra node modules, such that you don't have to always install the latest module.

*Also verify you have:*

* [x] Read the [contributions](../CONTRIBUTING.md) page.
* [x] Read the [DCO](../DCO), if you are a first time contributor.
* [x] Read the [code of conduct]([Code of Conduct] (https://github.com/SchwarzIT/.github/blob/main/CODE_OF_CONDUCT.md)).