### PR TITLE
Fix typo in chart README

### DIFF
--- a/charts/node-red/README.md
+++ b/charts/node-red/README.md
@@ -179,7 +179,7 @@ The `k8s-sidecar` will then call the `node-red` api to reload the flows. This wi
 of your admin user. The admin user needs to have the right to use the `node-red` API.
 
 The `k8s-sidecar` can also call the `node-red` api to install additional node modules (npm packages) before refreshing or importing the flow.json.
-You need to list your flows requiert 'NODE_MODULES' in the `sidecar.extraNodeModules`: e.g.
+You need to list your flows required 'NODE_MODULES' in the `sidecar.extraNodeModules`: e.g.
 
 ```yaml
 sidecar:

--- a/charts/node-red/README.md.gotmpl
+++ b/charts/node-red/README.md.gotmpl
@@ -96,7 +96,7 @@ The `k8s-sidecar` will then call the `node-red` api to reload the flows. This wi
 of your admin user. The admin user needs to have the right to use the `node-red` API.
 
 The `k8s-sidecar` can also call the `node-red` api to install additional node modules (npm packages) before refreshing or importing the flow.json.
-You need to list your flows requiert 'NODE_MODULES' in the `sidecar.extraNodeModules`: e.g.
+You need to list your flows required 'NODE_MODULES' in the `sidecar.extraNodeModules`: e.g.
 
 ```yaml
 sidecar:


### PR DESCRIPTION
### Thank you for making `node-red ⚙` better

Found a typo in the chart README :wink: 

*Also verify you have:*

* [x] Read the [contributions](../CONTRIBUTING.md) page.
* [x] Read the [DCO](../DCO), if you are a first time contributor.
* [x] Read the [code of conduct]([Code of Conduct](https://github.com/SchwarzIT/.github/blob/main/CODE_OF_CONDUCT.md)).