### PR TITLE
Add persistence.existingClaim to value documentation

### DIFF
--- a/charts/node-red/README.md
+++ b/charts/node-red/README.md
@@ -104,6 +104,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | persistence.enabled | bool | `false` | Use persistent volume to store data |
 | persistence.keepPVC | bool | `false` | ## Keep a created Persistent volume claim when uninstalling the helm chart (default: false) |
 | persistence.size | string | `"5Gi"` | Size of persistent volume claim |
+| persistence.existingClaim | string | `""` | Do not create, but use an existing volume claim with the provided name |
 | podAnnotations | object | `{}` | Pod annotations |
 | podLabels | object | `{}` | Labels to add to the node-red pod. default: {} |
 | podSecurityContext | object | `{"fsGroup":1000,"runAsUser":1000}` | Pod Security Context see [values.yaml](values.yaml) |


### PR DESCRIPTION
This PR adds the `persistence.existingClaim` value to the Chart documentation for completeness.

I often provide my own PVC to make managing of volumes easier, so being able to provide an existing claim is essential. At first I thought this Helm chart does not allow me to do that, but then realized that the option was just not documented, so I would like to add this value to the documentation.


*Also verify you have:*

* [x] Read the [contributions](../CONTRIBUTING.md) page.
* [x] Read the [DCO](../DCO), if you are a first time contributor.
* [x] Read the [code of conduct]([Code of Conduct](https://github.com/SchwarzIT/.github/blob/main/CODE_OF_CONDUCT.md)).