### PR TITLE
feat: Allows template inside .Values.env

### DIFF
--- a/charts/node-red/Chart.yaml
+++ b/charts/node-red/Chart.yaml
@@ -9,7 +9,7 @@ icon: https://nodered.org/about/resources/media/node-red-icon-2.png
 
 type: application
 
-version: 0.33.0
+version: 0.33.1
 appVersion: 4.0.3
 
 keywords:
@@ -29,7 +29,7 @@ maintainers:
 annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - update docker.io/nodered/node-red to 4.0.3
+    - feat: Allows template inside .Values.env
   artifacthub.io/images: |
     - name: node-red
       image: docker.io/nodered/node-red:4.0.3

--- a/charts/node-red/Chart.yaml
+++ b/charts/node-red/Chart.yaml
@@ -29,7 +29,7 @@ maintainers:
 annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - feat: Allows template inside .Values.env
+    - Allows template inside .Values.env
   artifacthub.io/images: |
     - name: node-red
       image: docker.io/nodered/node-red:4.0.3

--- a/charts/node-red/README.md
+++ b/charts/node-red/README.md
@@ -1,6 +1,6 @@
 # node-red ⚙
 
-![Version: 0.33.0](https://img.shields.io/badge/Version-0.33.0-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 4.0.3](https://img.shields.io/badge/AppVersion-4.0.3-informational?style=for-the-badge)
+![Version: 0.33.1](https://img.shields.io/badge/Version-0.33.1-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 4.0.3](https://img.shields.io/badge/AppVersion-4.0.3-informational?style=for-the-badge)
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/node-red&style=for-the-badge)](https://artifacthub.io/packages/search?repo=node-red)
 [![SIT](https://img.shields.io/badge/SIT-awesome-blueviolet.svg?style=for-the-badge)](https://jobs.schwarz)
@@ -16,7 +16,7 @@ A Helm chart for Node-Red, a low-code programming for event-driven applications
 To install the chart using the OCI artifact, run:
 
 ```bash
-helm install node-red oci://ghcr.io/schwarzit/charts/node-red --version 0.33.0
+helm install node-red oci://ghcr.io/schwarzit/charts/node-red --version 0.33.1
 ```
 
 ## Usage
@@ -32,7 +32,7 @@ helm repo update
 To install the chart with the release name node-red run:
 
 ```bash
-helm install node-red node-red/node-red --version 0.33.0
+helm install node-red node-red/node-red --version 0.33.1
 ```
 
 After a few seconds, node-red should be running.

--- a/charts/node-red/templates/deployment.yaml
+++ b/charts/node-red/templates/deployment.yaml
@@ -124,7 +124,7 @@ spec:
             value: {{ .Values.metrics.path | default "/metrics" }}
           {{- end }}
           {{- with .Values.env }}
-          {{- toYaml . | nindent 10 }}
+          {{- tpl (toYaml .) $ | nindent 10 }}
           {{- end }}
           {{- end }}
           {{- if .Values.envFrom }}


### PR DESCRIPTION
This PR allows template inside .Values.env :

When the node-red-chart is used as a subchart in a larger deployment, environment variables should be shared within .Values.global.env to avoid unnecessary duplication. 
This feature is specifically required when the kube is behind a http/https proxy.
In addition, environment variables used by the NodeRED flow can now easily be customized for each type of deployment (dev/prod).

*Also verify you have:*

* [x] Read the [contributions](../CONTRIBUTING.md) page.
* [x] Read the [DCO](../DCO), if you are a first time contributor.
* [x] Read the [code of conduct]([Code of Conduct](https://github.com/SchwarzIT/.github/blob/main/CODE_OF_CONDUCT.md)).