### PR TITLE
fix: correct broken links in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,6 @@ Please reference the issue this PR is fixing.
 
 *Also verify you have:*
 
-* [ ] Read the [contributions](../CONTRIBUTING.md) page.
-* [ ] Read the [DCO](../DCO), if you are a first time contributor.
-* [ ] Read the [code of conduct]([Code of Conduct](https://github.com/SchwarzIT/.github/blob/main/CODE_OF_CONDUCT.md)).
+* [ ] Read the [contributions](/CONTRIBUTING.md) page.
+* [ ] Read the [DCO](/DCO), if you are a first time contributor.
+* [ ] Read the [code of conduct](https://github.com/SchwarzIT/.github/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary

- Fix broken links in the pull request template by changing relative paths (`../`) to absolute paths (`/`) for CONTRIBUTING.md and DCO files
- Fix malformed markdown link syntax for code of conduct link

## Test plan

- [ ] Verify links work correctly when creating a new PR
- [ ] Click on each link in the PR template to confirm they resolve properly

Fixes #485