### PR TITLE
fix(ci): update Helm to v3.18.10 for platformHooks support

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
-          version: v3.6.3
+          version: v3.18.10
 
       - name: Set up python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0


### PR DESCRIPTION
## Summary
- Updates Helm version in CI workflow from v3.6.3 to v3.18.10

## Problem
The chart uses `platformHooks` which was introduced in Helm v3.18.0. The CI workflow was using Helm v3.6.3 which doesn't recognize this feature, causing linting failures with errors like:

```
Error: unable to load chart
	cannot load Chart.yaml: yaml: unmarshal errors:
	  line 63: field platformHooks not found in type chart.Metadata
```

This particularly affects **fork PRs** since they use the workflow from `main`, not from the PR branch.

## Test plan
- [ ] CI should pass on this PR
- [ ] Once merged, fork PRs that modify charts will be able to pass CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)