### PR TITLE
fix(ci): correct Helm version to v3.19.4

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
-          version: v3.18.10
+          version: v3.19.4
 
       - name: Set up python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0


### PR DESCRIPTION
## Summary
- Fixes the Helm version in CI from v3.18.10 (non-existent) to v3.19.4 (actual latest v3.x)

## Problem
The previous commit (#506) used Helm v3.18.10 which does not exist, causing the setup-helm action to fail with:
```
Error: Failed to download Helm from location https://get.helm.sh/helm-v3.18.10-linux-amd64.tar.gz
```

## Solution
Updated to v3.19.4, which is the actual latest Helm v3.x release.