### PR TITLE
ci: pin Helm version to v3.19.4 in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        with:
+          version: v3.19.4
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
## Summary
- Explicitly pins Helm version to v3.19.4 in the `publish.yaml` workflow for consistency with `lint-and-test.yml`
- Ensures predictable builds by avoiding implicit version changes

## Context
The latest Helm version is **v4.0.4**, but Helm 4 introduces significant breaking changes:

- **Server-Side Apply (SSA)** replaces three-way merge by default
- **Redesigned plugin system** - post-renderers must now be plugins
- **Registry login changes** - must use domain name only
- **CLI flag renaming** - various flags have been renamed

Helm 3.19.4 is the latest stable Helm 3 release and is the safer choice for CI workflows until thorough testing with Helm 4 is completed. Helm 3 remains supported for:
- Bug fixes until July 8, 2026
- Security fixes until November 11, 2026

## Test plan
- [ ] Verify publish workflow runs successfully with pinned Helm version
- [ ] Confirm chart releases continue to work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)