### PR TITLE
fix(deployment): evaluate initContainers template

### DIFF
--- a/charts/node-red/templates/deployment.yaml
+++ b/charts/node-red/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       {{- if .Values.initContainers  }}
       initContainers:
       {{- with .Values.initContainers }}
-        {{- toYaml . | nindent 6 }}
+        {{- tpl (toYaml .) $ | nindent 6 }}
       {{- end }}
       {{- end }}
       containers:


### PR DESCRIPTION
### Thank you for making `node-red ⚙` better

Please reference the issue this PR is fixing. There's no issue that this PR fixes. I can open one if needed. 

Rendering the `initContainers` as helm templates allows referencing values in them, like being able to use the same image on the main and init containers. 

For example: 
```yaml
initContainers:
  - name: test-container
    image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
    command: ["/bin/sh", "-c", "echo Hello from the test container! && sleep 30"]
```

Other projects also do this: https://github.com/apache/superset/pull/31878
*Also verify you have:*

* [X] Read the [contributions](/CONTRIBUTING.md) page.
* [X] Read the [DCO](/DCO), if you are a first time contributor.
* [X] Read the [code of conduct](https://github.com/SchwarzIT/.github/blob/main/CODE_OF_CONDUCT.md).