### PR TITLE
feat(sidecar): Add option to adjust the sidecar URL env

### DIFF
--- a/charts/node-red/Chart.yaml
+++ b/charts/node-red/Chart.yaml
@@ -9,7 +9,7 @@ icon: https://nodered.org/about/resources/media/node-red-icon-2.png
 
 type: application
 
-version: 0.40.1
+version: 0.40.2
 appVersion: 4.1.2
 
 keywords:

--- a/charts/node-red/templates/deployment.yaml
+++ b/charts/node-red/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
             value: /app/{{ .Values.sidecar.env.script }}
           {{- end }}
           - name: URL
-            value: {{ printf "http://%s.%s.svc.cluster.local:%d" (include "node-red.fullname" .) .Release.Namespace (.Values.service.port | int) }}
+            value: {{ .Values.sidecar.env.url | default (printf "http://%s.%s.svc.cluster.local:%d" (include "node-red.fullname" .) .Release.Namespace (.Values.service.port | int)) | quote }}
           {{ if .Values.sidecar.env.username }}
           - name: USERNAME
             value: {{ .Values.sidecar.env.username }}

--- a/charts/node-red/values.yaml
+++ b/charts/node-red/values.yaml
@@ -313,6 +313,8 @@ sidecar:
     #  key: password
     # -- Skip the initial request to REQ_URL when using watch mode (v2.1.0+)
     skip_init: false
+    # -- Optional: Custom target URL for the sidecar. If left empty, the internal service cluster URL is used automatically.
+    url: ""
   # -- Extra Node-Modules that will be installed  from the sidecar script
   extraNodeModules: []
   # -- Extra Environments for the sidecar


### PR DESCRIPTION
### Problem
The URL environment variable for the node-red-sidecar container was hardcoded to use an internal cluster URL structure (http://<fullname>.<namespace>.svc.cluster.local:<port>). This prevented users from pointing the sidecare to a different service endpoint which is necessary for e.g. an HA Setup.

### Solution
- Modified the deployment.yaml template to make the URL variable configurable.
- Introduced a new url parameter in the values.yaml under .Values.sidecar.env.
- If .Values.sidecar.env.url is not set or left empty, the chart automatically falls back to generating the original dynamic internal cluster URL.


### Thank you for making `node-red ⚙` better

*Also verify you have:*

* [ x] Read the [contributions](/CONTRIBUTING.md) page.
* [ x] Read the [DCO](/DCO), if you are a first time contributor.
* [ x] Read the [code of conduct](https://github.com/SchwarzIT/.github/blob/main/CODE_OF_CONDUCT.md).