### PR TITLE
Add aPI Gateway support

### DIFF
--- a/charts/node-red/README.md
+++ b/charts/node-red/README.md
@@ -1,6 +1,6 @@
 # node-red ⚙
 
-![Version: 0.40.1](https://img.shields.io/badge/Version-0.40.1-informational?style=for-the-badge)
+![Version: 0.40.2](https://img.shields.io/badge/Version-0.40.2-informational?style=for-the-badge)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge)
 ![AppVersion: 4.1.2](https://img.shields.io/badge/AppVersion-4.1.2-informational?style=for-the-badge)
 
@@ -18,7 +18,7 @@ A Helm chart for Node-Red, a low-code programming for event-driven applications
 To install the chart using the OCI artifact, run:
 
 ```bash
-helm install node-red oci://ghcr.io/schwarzit/charts/node-red --version 0.40.1
+helm install node-red oci://ghcr.io/schwarzit/charts/node-red --version 0.40.2
 ```
 
 ## Usage
@@ -34,7 +34,7 @@ helm repo update
 To install the chart with the release name node-red run:
 
 ```bash
-helm install node-red node-red/node-red --version 0.40.1
+helm install node-red node-red/node-red --version 0.40.2
 ```
 
 After a few seconds, node-red should be running.
@@ -73,6 +73,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | extraVolumeMounts | string | `nil` | Extra Volume Mounts for the node-red pod |
 | extraVolumes | string | `nil` | Extra Volumes for the pod |
 | fullnameOverride | string | `""` | String to fully override "node-red.fullname" |
+| httpRoute.annotations | object | `{}` | Additional HTTPRoute annotations |
+| httpRoute.enabled | bool | `false` | Enable an HTTPRoute resource for the server |
+| httpRoute.hostnames | list | `[]` | Hostnames exposed by the HTTPRoute |
+| httpRoute.parentRefs | list | `[]` | Parent references for Gateway API attachment |
+| httpRoute.rules | list | `[{"backendRefs":[],"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | HTTPRoute rules. If backendRefs is empty, traffic is forwarded to this chart's service. |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy |
 | image.registry | string | `"docker.io"` | The image registry to pull from |
 | image.repository | string | `"nodered/node-red"` | The image repository to pull from |
@@ -134,6 +139,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | sidecar.env.script | string | `"flow_refresh.py"` | Absolute path to shell script to execute after a configmap got reloaded. |
 | sidecar.env.skip_init | bool | `false` | Skip the initial request to REQ_URL when using watch mode (v2.1.0+) |
 | sidecar.env.sleep_time_sidecar | string | `"5s"` | Set the sleep time for refresh script |
+| sidecar.env.url | string | `""` | Optional: Custom target URL for the sidecar. If left empty, the internal service cluster URL is used automatically. |
 | sidecar.env.username | string | `""` |  |
 | sidecar.extraEnv | list | `[]` | Extra Environments for the sidecar |
 | sidecar.extraNodeModules | list | `[]` | Extra Node-Modules that will be installed  from the sidecar script |
@@ -163,6 +169,24 @@ helm install node-red node-red/node-red -f values.yaml
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Gateway API HTTPRoute
+
+This chart can expose Node-RED via Gateway API using `HTTPRoute`.
+
+Example:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: edge-gateway
+      sectionName: web
+  hostnames:
+    - nodered.example.com
+```
+
+If a rule does not define `backendRefs`, the chart routes traffic to the default Node-RED service and `service.port`.
 
 ## Monitoring 🌡️
 To enable the node-red prometheus monitoring capability, you need to install the node `node-red-contrib-prometheus-exporter`.

--- a/charts/node-red/README.md.gotmpl
+++ b/charts/node-red/README.md.gotmpl
@@ -78,6 +78,24 @@ helm install node-red node-red/node-red -f values.yaml
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
+## Gateway API HTTPRoute
+
+This chart can expose Node-RED via Gateway API using `HTTPRoute`.
+
+Example:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: edge-gateway
+      sectionName: web
+  hostnames:
+    - nodered.example.com
+```
+
+If a rule does not define `backendRefs`, the chart routes traffic to the default Node-RED service and `service.port`.
+
 ## Monitoring 🌡️
 To enable the node-red prometheus monitoring capability, you need to install the node `node-red-contrib-prometheus-exporter`.
 For more details see [official documentation](https://flows.nodered.org/node/node-red-contrib-prometheus-exporter)

--- a/charts/node-red/templates/NOTES.txt
+++ b/charts/node-red/templates/NOTES.txt
@@ -5,6 +5,14 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
+  {{- else if .Values.httpRoute.enabled }}
+  {{- if .Values.httpRoute.hostnames }}
+  {{- range $host := .Values.httpRoute.hostnames }}
+    http://{{ $host }}
+  {{- end }}
+  {{- else }}
+    HTTPRoute {{ include "node-red.fullname" . }} has no hostnames configured. Check your Gateway listener and route rules.
+  {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "node-red.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")

--- a/charts/node-red/templates/httproute.yaml
+++ b/charts/node-red/templates/httproute.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.httpRoute.enabled -}}
+{{- $fullName := include "node-red.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "node-red.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    - {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        {{- if .backendRefs }}
+        {{- toYaml .backendRefs | nindent 8 }}
+        {{- else }}
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/node-red/tests/httproute_test.yaml
+++ b/charts/node-red/tests/httproute_test.yaml
@@ -1,0 +1,46 @@
+suite: test httproute template
+templates:
+  - httproute.yaml
+tests:
+  - it: should not render, when httpRoute.enabled=false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render defaults, when httpRoute.enabled=true
+    set:
+      httpRoute.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-node-red
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 1880
+
+  - it: should render custom parentRefs, hostnames and backendRefs
+    values:
+      - ./values/httproute_values.yaml
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].name
+          value: edge-gateway
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: web
+      - equal:
+          path: spec.hostnames[0]
+          value: nodered.example.com
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /flows
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: custom-backend
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8080

--- a/charts/node-red/tests/values/httproute_values.yaml
+++ b/charts/node-red/tests/values/httproute_values.yaml
@@ -1,0 +1,15 @@
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: edge-gateway
+      sectionName: web
+  hostnames:
+    - nodered.example.com
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /flows
+      backendRefs:
+        - name: custom-backend
+          port: 8080

--- a/charts/node-red/values.yaml
+++ b/charts/node-red/values.yaml
@@ -199,6 +199,23 @@ ingress:
     # -- Name of the Issuer
     #     name: "test"
 
+httpRoute:
+  # -- Enable an HTTPRoute resource for the server
+  enabled: false
+  # -- Additional HTTPRoute annotations
+  annotations: {}
+  # -- Parent references for Gateway API attachment
+  parentRefs: []
+  # -- Hostnames exposed by the HTTPRoute
+  hostnames: []
+  # -- HTTPRoute rules. If backendRefs is empty, traffic is forwarded to this chart's service.
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs: []
+
 # -- Startup probe for the Deployment
 startupProbe:
   httpGet:


### PR DESCRIPTION
### Adding HttpRoute in order to support API Gateway, which will eventually replace Ingresses
I have added support for HttpRoute. As this is a feature required to slowly move away from Ingresses.
With the deprecation and sunsetting of Nginx Ingress support from the Kubernetes community, is a good oportunity to extend this helm-chart's support of functions.

*Also verify you have:*

* [x] Read the [contributions](/CONTRIBUTING.md) page.
* [x] Read the [DCO](/DCO), if you are a first time contributor.
* [x] Read the [code of conduct](https://github.com/SchwarzIT/.github/blob/main/CODE_OF_CONDUCT.md).